### PR TITLE
[WIP] Bump to Ubuntu 18.04 LTS / JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ jdk:
 - openjdk11
 before_install:
 - export TZ=Europe/Helsinki
-branches:
-  only:
-  - develop
-  - master
+# branches:
+#   only:
+#   - develop
+#   - master
 install: true
 script: ./mvnw clean install -P\!dependency-check -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 after_success:
 - "./mvnw jacoco:report coveralls:report -Dcoveralls.repo.token=$COVERALLS_REPO_TOKEN"
-notifications:
-  email:
-    recipients:
-    - aare.nurm@nortal.com
-    - siim.suu@nortal.com
-    - risto.seene@nortal.com
-    on_success: change
-    on_failure: always
+# notifications:
+#   email:
+#     recipients:
+#     - aare.nurm@nortal.com
+#     - siim.suu@nortal.com
+#     - risto.seene@nortal.com
+#     on_success: change
+#     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: java
 sudo: false
 cache: false


### PR DESCRIPTION
This pull request is WIP and there are still some failures:

1. `mvn compile` fails at the `siva-webapp` subpackage:
```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:50)
Caused by: java.lang.AssertionError
	at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
	at jdk.compiler/com.sun.tools.javac.util.Assert.check(Assert.java:46)
	at jdk.compiler/com.sun.tools.javac.comp.Modules.enter(Modules.java:247)
	at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.readSourceFile(JavaCompiler.java:837)
	at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$ImplicitCompleter.complete(JavacProcessingEnvironment.java:1521)
	at jdk.compiler/com.sun.tools.javac.code.Symbol.complete(Symbol.java:642)
	at jdk.compiler/com.sun.tools.javac.code.Symbol$ClassSymbol.complete(Symbol.java:1326)
	at jdk.compiler/com.sun.tools.javac.code.Type$ClassType.complete(Type.java:1140)
	at jdk.compiler/com.sun.tools.javac.code.Type$ClassType.getTypeArguments(Type.java:1066)
	at jdk.compiler/com.sun.tools.javac.code.Printer.visitClassType(Printer.java:237)
	at jdk.compiler/com.sun.tools.javac.code.Printer.visitClassType(Printer.java:52)
	at jdk.compiler/com.sun.tools.javac.code.Type$ClassType.accept(Type.java:993)
	at jdk.compiler/com.sun.tools.javac.code.Printer.visit(Printer.java:136)
	at jdk.compiler/com.sun.tools.javac.util.AbstractDiagnosticFormatter.formatArgument(AbstractDiagnosticFormatter.java:199)
	at jdk.compiler/com.sun.tools.javac.util.AbstractDiagnosticFormatter.formatArguments(AbstractDiagnosticFormatter.java:167)
	at jdk.compiler/com.sun.tools.javac.util.BasicDiagnosticFormatter.formatMessage(BasicDiagnosticFormatter.java:111)
	at jdk.compiler/com.sun.tools.javac.util.BasicDiagnosticFormatter.formatMessage(BasicDiagnosticFormatter.java:67)
	at jdk.compiler/com.sun.tools.javac.util.AbstractDiagnosticFormatter.formatArgument(AbstractDiagnosticFormatter.java:185)
	at jdk.compiler/com.sun.tools.javac.util.AbstractDiagnosticFormatter.formatArguments(AbstractDiagnosticFormatter.java:167)
	at jdk.compiler/com.sun.tools.javac.util.BasicDiagnosticFormatter.formatMessage(BasicDiagnosticFormatter.java:111)
	at jdk.compiler/com.sun.tools.javac.util.BasicDiagnosticFormatter.formatMessage(BasicDiagnosticFormatter.java:67)
	at jdk.compiler/com.sun.tools.javac.util.JCDiagnostic.getMessage(JCDiagnostic.java:788)
	at jdk.compiler/com.sun.tools.javac.api.ClientCodeWrapper$DiagnosticSourceUnwrapper.getMessage(ClientCodeWrapper.java:799)
	at org.codehaus.plexus.compiler.javac.JavaxToolsCompiler.compileInProcess(JavaxToolsCompiler.java:131)
	at org.codehaus.plexus.compiler.javac.JavacCompiler.performCompile(JavacCompiler.java:174)
	at org.apache.maven.plugin.compiler.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:1129)
	at org.apache.maven.plugin.compiler.CompilerMojo.execute(CompilerMojo.java:188)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	...
```

2. `mvn install` fails while testing `xroad-validation-service`:
```
[INFO] Running ee.openeid.siva.xroad.validation.XROADValidationReportTest
[ERROR] Tests run: 11, Failures: 0, Errors: 9, Skipped: 0, Time elapsed: 4.243 s 
[ERROR] Errors: 
[ERROR]   XROADErroneousDocumentsTest.reportWithErrorsAndIndicationTotalFailedShouldBeReturnedWhenAsicVerificationThrowsException:48 » NoClassDefFound
[ERROR]   XROADValidationReportTest.ValidatingXRoadSimpleContainerShouldHaveOnlyTheCNFieldOfTheSingersCerificateAsSignedByFieldInValidationReport:56 » NoClassDefFound
[ERROR]   XROADValidationReportTest.onlySimpleReportPresentInDocumentValidationResultReports:125 » NoClassDefFound
[ERROR]   XROADValidationReportTest.signatureFormInReportShouldBeAsicEWhenValidatingXROADSimpleContainer:79 » NoClassDefFound
[ERROR]   XROADValidationReportTest.signatureFormatInReportShouldBeXadesBaselineBWhenValidatingXROADBatchSignature:85 » NoClassDefFound
[ERROR]   XROADValidationReportTest.signatureFormatInReportShouldBeXadesBaselineLTWhenValidatingXROADSimpleContainer:91 » NoClassDefFound
[ERROR]   XROADValidationReportTest.validationReportForXROADSimpleAndPatchSignatureShouldHaveEmptySignatureLevel:71 » NoClassDefFound
[ERROR]   XROADValidationReportTest.validationReportForXroadBatchSignatureShouldHaveCorrectSignatureForm:64 » NoClassDefFound
[ERROR]   XROADValidationReportTest.validationReportShouldContainDefaultPolicyWhenPolicyIsNotExplicitlyGiven:97->validateWithPolicy:146 » NoClassDefFound
[ERROR]   XROADValidationReportTest.validationReportShouldContainNoTypePolicyWhenNoTypePolicyIsGivenToValidator:105->validateWithPolicy:146 » NoClassDefFound
```