### PR TITLE
Report trusted-list readiness in health endpoints

### DIFF
--- a/docs/siva3/deployment_guide.md
+++ b/docs/siva3/deployment_guide.md
@@ -338,6 +338,7 @@ management.endpoint.heartbeat.enabled=true
 * **Simplified service health indicator**
 
 The endpoint is implemented by polling the health information directly from the underlying health endpoint implementation, but exposing just the aggregated overall service status, hiding everything else.
+The aggregated status is **DOWN** when any configured trusted-list source contains no trusted certificates.
 
 ## Version information endpoint
 

--- a/docs/siva3/interfaces.md
+++ b/docs/siva3/interfaces.md
@@ -508,7 +508,10 @@ GET https://<server url>/monitoring/health
 ### The response
 The response is provided and documented by Spring Boot Actuator — see the [Spring Boot health endpoint](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health).
 Exact shape depends on the Spring Boot version and the [active configuration](https://github.com/open-eid/SiVa/blob/master/siva-parent/siva-webapp/src/main/resources/application.yml). 
-SiVa contributes one additional health indicator, `components.health`, with the following details:
+SiVa contributes the `components.health` and `components.trustedLists` health indicators.
+`components.trustedLists` is **DOWN** when any configured trusted-list source contains no trusted certificates;
+its `details.trustedCertificateCounts` field reports the certificate count per source.
+`components.health` provides the following details:
 
 | Field | Description                                                                                                                |
 | ---------|----------------------------------------------------------------------------------------------------------------------------|
@@ -533,6 +536,10 @@ Sample response:
         "startTime": "2016-10-21T15:57:48Z",
         "currentTime": "2016-10-21T15:58:39Z"
       }
+    },
+    "trustedLists": {
+      "status": "UP",
+      "details": { "trustedCertificateCounts": { "generic": 120, "timemark": 118 } }
     },
     "ping": { "status": "UP" },
     "livenessState": { "status": "UP" },

--- a/siva-parent/siva-monitoring/pom.xml
+++ b/siva-parent/siva-monitoring/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>ee.openid.siva</groupId>
+            <artifactId>tsl-loader</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/siva-parent/siva-monitoring/src/main/java/ee/openeid/siva/monitoring/configuration/MonitoringConfiguration.java
+++ b/siva-parent/siva-monitoring/src/main/java/ee/openeid/siva/monitoring/configuration/MonitoringConfiguration.java
@@ -19,10 +19,14 @@ package ee.openeid.siva.monitoring.configuration;
 import ee.openeid.siva.monitoring.enpoint.HeartbeatEndpoint;
 import ee.openeid.siva.monitoring.enpoint.VersionEndpoint;
 import ee.openeid.siva.monitoring.indicator.ApplicationHealthIndicator;
+import ee.openeid.siva.monitoring.indicator.TrustedListHealthIndicator;
 import ee.openeid.siva.monitoring.util.ManifestReader;
+import ee.openeid.tsl.TSLLoader;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
 import org.springframework.context.annotation.Bean;
+
+import java.util.Set;
 
 
 public abstract class MonitoringConfiguration {
@@ -38,6 +42,11 @@ public abstract class MonitoringConfiguration {
     @Bean
     public ApplicationHealthIndicator health(ManifestReader manifestReader) {
         return new ApplicationHealthIndicator(manifestReader);
+    }
+
+    @Bean
+    public TrustedListHealthIndicator trustedLists(Set<TSLLoader> tslLoaders) {
+        return new TrustedListHealthIndicator(tslLoaders);
     }
 
     @Bean

--- a/siva-parent/siva-monitoring/src/main/java/ee/openeid/siva/monitoring/indicator/TrustedListHealthIndicator.java
+++ b/siva-parent/siva-monitoring/src/main/java/ee/openeid/siva/monitoring/indicator/TrustedListHealthIndicator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Mindaugas Kiškis
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+
+package ee.openeid.siva.monitoring.indicator;
+
+import ee.openeid.tsl.TSLLoader;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+@RequiredArgsConstructor
+public class TrustedListHealthIndicator implements HealthIndicator {
+
+    public static final String RESPONSE_PARAM_TRUSTED_CERTIFICATE_COUNTS = "trustedCertificateCounts";
+
+    @NonNull
+    private final Set<TSLLoader> tslLoaders;
+
+    @Override
+    public Health health() {
+        Map<String, Integer> trustedCertificateCounts = new TreeMap<>();
+        for (TSLLoader tslLoader : tslLoaders) {
+            trustedCertificateCounts.put(tslLoader.getTslName(), tslLoader.getTrustedCertificateCount());
+        }
+
+        boolean ready = !trustedCertificateCounts.isEmpty()
+                && trustedCertificateCounts.values().stream().allMatch(count -> count > 0);
+        Health.Builder health = ready ? Health.up() : Health.down();
+        return health
+                .withDetail(RESPONSE_PARAM_TRUSTED_CERTIFICATE_COUNTS, trustedCertificateCounts)
+                .build();
+    }
+}

--- a/siva-parent/siva-monitoring/src/test/java/ee/openeid/siva/monitoring/indicator/TrustedListHealthIndicatorTest.java
+++ b/siva-parent/siva-monitoring/src/test/java/ee/openeid/siva/monitoring/indicator/TrustedListHealthIndicatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Mindaugas Kiškis
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved by
+ * the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+
+package ee.openeid.siva.monitoring.indicator;
+
+import ee.openeid.tsl.TSLLoader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrustedListHealthIndicatorTest {
+
+    @Mock
+    private TSLLoader genericTslLoader;
+    @Mock
+    private TSLLoader timemarkTslLoader;
+
+    @Test
+    void healthIsUpWhenEveryTrustedListContainsCertificates() {
+        when(genericTslLoader.getTslName()).thenReturn("generic");
+        when(genericTslLoader.getTrustedCertificateCount()).thenReturn(120);
+        when(timemarkTslLoader.getTslName()).thenReturn("timemark");
+        when(timemarkTslLoader.getTrustedCertificateCount()).thenReturn(118);
+
+        Health health = new TrustedListHealthIndicator(Set.of(genericTslLoader, timemarkTslLoader)).health();
+
+        assertEquals(Status.UP, health.getStatus());
+        assertEquals(
+                Map.of("generic", 120, "timemark", 118),
+                health.getDetails().get(TrustedListHealthIndicator.RESPONSE_PARAM_TRUSTED_CERTIFICATE_COUNTS)
+        );
+    }
+
+    @Test
+    void healthIsDownWhenAnyTrustedListIsEmpty() {
+        when(genericTslLoader.getTslName()).thenReturn("generic");
+        when(genericTslLoader.getTrustedCertificateCount()).thenReturn(0);
+        when(timemarkTslLoader.getTslName()).thenReturn("timemark");
+        when(timemarkTslLoader.getTrustedCertificateCount()).thenReturn(118);
+
+        Health health = new TrustedListHealthIndicator(Set.of(genericTslLoader, timemarkTslLoader)).health();
+
+        assertEquals(Status.DOWN, health.getStatus());
+        assertEquals(
+                Map.of("generic", 0, "timemark", 118),
+                health.getDetails().get(TrustedListHealthIndicator.RESPONSE_PARAM_TRUSTED_CERTIFICATE_COUNTS)
+        );
+    }
+
+    @Test
+    void healthIsDownWhenNoTrustedListLoadersExist() {
+        Health health = new TrustedListHealthIndicator(Set.of()).health();
+
+        assertEquals(Status.DOWN, health.getStatus());
+        assertEquals(
+                Map.of(),
+                health.getDetails().get(TrustedListHealthIndicator.RESPONSE_PARAM_TRUSTED_CERTIFICATE_COUNTS)
+        );
+    }
+}

--- a/validation-services-parent/tsl-loader/src/main/java/ee/openeid/tsl/TSLLoader.java
+++ b/validation-services-parent/tsl-loader/src/main/java/ee/openeid/tsl/TSLLoader.java
@@ -91,6 +91,10 @@ public class TSLLoader {
         }
     }
 
+    public int getTrustedCertificateCount() {
+        return trustedListSource.getNumberOfCertificates();
+    }
+
     public LOTLSource europeanLOTL() {
         LOTLSource lotlSource = new LOTLSource();
         lotlSource.setUrl(configurationProperties.getUrl());

--- a/validation-services-parent/tsl-loader/src/test/java/ee/openeid/tsl/TSLLoaderTest.java
+++ b/validation-services-parent/tsl-loader/src/test/java/ee/openeid/tsl/TSLLoaderTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -94,6 +95,15 @@ class TSLLoaderTest {
         verify(tslValidationJob).onlineRefresh();
         verifyNoMoreInteractions(tslValidationJobFactory, tslValidationJob);
         verifyNoInteractions(trustedListSource, keyStoreCertificateSource);
+    }
+
+    @Test
+    void getTrustedCertificateCount_ReturnsCertificateSourceSize() {
+        tslLoader.setTslLoaderConfigurationProperties(createConfigurationProperties(true));
+        tslLoader.init();
+        when(trustedListSource.getNumberOfCertificates()).thenReturn(123);
+
+        assertEquals(123, tslLoader.getTrustedCertificateCount());
     }
 
     private static TSLLoaderConfigurationProperties createConfigurationProperties(boolean loadFromCache) {


### PR DESCRIPTION
## What

Adds a `trustedLists` health indicator that reports trusted-certificate counts per configured TSL source. Health is `DOWN` when any source is empty, and the existing heartbeat endpoint inherits that aggregate status.

## Why

The application health indicator could remain `UP` after a failed LOTL refresh left SiVa with no trusted anchors. This makes that validation outage observable and suitable for readiness monitoring.

Related to #64. Complements #66.

## Verification

- `./mvnw -pl siva-parent/siva-monitoring -am test` – 283 tests passed
- `./mvnw -pl siva-parent/siva-webapp -am -DskipTests package` – 13-module webapp build passed

Signed-off-by: Mindaugas Kiškis <mkiskis@gmail.com>